### PR TITLE
Updating Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The intention is to build from here to create the all singing Electricomic edito
 The Releases tab contains prebuilt binaries for Windows and OS X. Linux users should be able to run from the **Running from source** section below.
 
 # Getting Started
-Until we produce some better instructions [here's a great article](http://dangergeekuk.blogspot.co.uk/2015/09/how-to-make-electricomic.html) by Tim West on getting started with the Generator
+Until we produce some better instructions, go to the [Releases page] and download the release made for your operating system. Also, [here's a great article](http://dangergeekuk.blogspot.co.uk/2015/09/how-to-make-electricomic.html) by Tim West on getting started with the Generator.
 
 # Generator Basics
 - You can Create, Open, Save and Close projects. A Project contains all the files needed for an Electricomic. When a project is open you can preview it or examine the generated files.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,5 @@ Until we produce some better instructions [here's a great article](http://danger
 - Download the source or clone the github repo
 - Install NodeJS from https://nodejs.org/
 - Install the required modules: _npm install_ from the projects folder
-- Install Node Webkit: _npm install nw -g_
-- From the electricomics-generator project folder run _nw_
+- From the "generator" project folder run _npm start_
 


### PR DESCRIPTION
The original installation instructions suggested running `npm install -global nw`. Globally installing nw is unnecessary for the project and on macOS does not install nw as command-line utility. Thus the next step, "run `nw`", fails.

Instead nw needs to be run from within the node environment. The best way to ensure this is done is by creating a `npm start` script. One was already created in the package.json file. Using it will ensure that the installation steps provided work on a wider range of environments.
